### PR TITLE
feat(cli): add audit-itunes command to surface tag discrepancies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ See [Step-by-step usage](#step-by-step-usage) for a full walkthrough including m
   - [Step 2 — Write tags to disk](#step-2--write-tags-to-disk)
   - [Step 3 — Handle albums that weren't matched](#step-3--handle-albums-that-werent-matched)
 - [Command reference](#command-reference)
+- [Repairing corrupted tags from iTunes](#repairing-corrupted-tags-from-itunes)
 - [Tips and troubleshooting](#tips-and-troubleshooting)
 
 ---
@@ -359,6 +360,8 @@ python -m tagger.mp3_tagger write
 | `retry-not-found` | Re-run enrichment on all `not_found` albums in DB |
 | `prefill-master-urls --csv <file>` | Pre-fill Discogs URLs in a manual-review CSV |
 | `enrich-missing --csv <file>` | Scan artist dirs missing from DB (run before `process-manual`) |
+| `audit-itunes --library <path> --itunes-xml <path>` | Compare current MP3 tags against iTunes Library XML; write discrepancy CSV |
+| `restore-from-itunes --library <path> --itunes-xml <path>` | Restore Artist, Album Artist, Album, and Track Number from iTunes ground truth |
 
 All commands share `--db-path` to point at a specific database file. The default is `tester.db` in the current directory.
 
@@ -441,6 +444,119 @@ Options:
   --db-path PATH       Database (default: tester.db)
   --token TEXT         Discogs token (overrides .env)
 ```
+
+---
+
+## Repairing corrupted tags from iTunes
+
+If a previous enrichment run overwrote Artist, Album Artist, Album, or track numbers with wrong values, you can use your iTunes library as a ground-truth reference to find and fix the damage. This workflow requires an exported iTunes Music Library XML file.
+
+### Where to find your iTunes XML
+
+In iTunes / Music on Windows:
+**Edit → Preferences → Advanced → "iTunes Media folder location"**. The XML file (`iTunes Music Library.xml`) lives in the same folder as your `.itl` file — typically:
+
+```
+C:\Users\<you>\Music\iTunes\iTunes Music Library.xml
+```
+
+If the file doesn't exist, open iTunes, go to **File → Library → Export Library…** and save it as XML.
+
+### Step 1 — Audit (find the discrepancies)
+
+```powershell
+python tagger/mp3_tagger.py audit-itunes `
+    --library "M:\Shared Music" `
+    --itunes-xml "C:\Users\you\Music\iTunes\iTunes Music Library.xml" `
+    --out itunes_audit.csv
+```
+
+This walks your library, reads each MP3's current ID3 tags, and fuzzy-matches them against the iTunes record for the same file. It writes `itunes_audit.csv` with one row per file that has at least one problem.
+
+**Output columns:**
+
+| Column | Description |
+|---|---|
+| `file_path` | Full path to the MP3 |
+| `mp3_artist` / `itunes_artist` | Current tag vs iTunes value |
+| `mp3_album_artist` / `itunes_album_artist` | Current tag vs iTunes value |
+| `mp3_album` / `itunes_album` | Current tag vs iTunes value |
+| `mp3_track_number` / `itunes_track_number` | Current tag vs iTunes value |
+| `issues` | Pipe-separated list: `artist_mismatch`, `album_artist_mismatch`, `album_mismatch`, `missing_track_number`, `itunes_not_found` |
+| `artist_score` / `album_score` / `album_artist_score` | Fuzzy similarity 0–100 (100 = identical) |
+
+**Console summary example:**
+```
+[+] 1 247 discrepancy row(s) found.
+    album_mismatch: 843
+    artist_mismatch: 312
+    missing_track_number: 4 102
+[+] Report written to itunes_audit.csv
+```
+
+**Options:**
+```
+--library PATH        Music library root (required)
+--itunes-xml PATH     Path to iTunes Music Library.xml (required)
+--out PATH            Output CSV (default: itunes_audit.csv)
+--threshold INT       Fuzzy score below which a field is flagged (default: 75)
+--workers INT         Parallel tag-read threads (default: 4)
+```
+
+### Step 2 — Dry-run restore (preview the fixes)
+
+```powershell
+python tagger/mp3_tagger.py restore-from-itunes `
+    --library "M:\Shared Music" `
+    --itunes-xml "C:\Users\you\Music\iTunes\iTunes Music Library.xml" `
+    --out restore_report.csv `
+    --dry-run
+```
+
+`--dry-run` runs the full comparison and writes the report CSV showing exactly what *would* change — without modifying any files. Review `restore_report.csv` before proceeding.
+
+**Report columns:**
+
+| Column | Description |
+|---|---|
+| `file_path` | Full path to the MP3 |
+| `fields_restored` | Pipe-separated list of fields that were (or would be) fixed |
+| `old_artist` / `new_artist` | Before and after for the Artist tag |
+| `old_album_artist` / `new_album_artist` | Before and after for Album Artist |
+| `old_album` / `new_album` | Before and after for Album |
+| `old_track_number` / `new_track_number` | Before and after for Track Number |
+| `dry_run` | `True` when run with `--dry-run` |
+
+### Step 3 — Apply the fixes
+
+Once you're satisfied with the dry-run report, run without `--dry-run` to write the corrections:
+
+```powershell
+python tagger/mp3_tagger.py restore-from-itunes `
+    --library "M:\Shared Music" `
+    --itunes-xml "C:\Users\you\Music\iTunes\iTunes Music Library.xml" `
+    --out restore_report.csv
+```
+
+Only the affected ID3 frames are overwritten. Every other tag (genre, year, grouping, artwork, etc.) is left exactly as-is.
+
+**Track number fallback:** If iTunes has no track number for a file, the restorer attempts to parse it from the filename prefix — e.g. `03 Song.mp3` → track 3, `2-05 Song.mp3` → disc 2 track 5.
+
+**Options:**
+```
+--library PATH        Music library root (required)
+--itunes-xml PATH     Path to iTunes Music Library.xml (required)
+--out PATH            Output report CSV (default: itunes_restore_report.csv)
+--threshold INT       Fuzzy score below which a field is treated as mismatched (default: 75)
+--workers INT         Parallel tag-read threads (default: 4)
+--dry-run             Preview without writing any files
+```
+
+### Notes
+
+- Files not found in the iTunes index (`itunes_not_found`) are skipped by the restorer — it only writes values it can verify against iTunes.
+- Both commands are idempotent — re-running after a partial failure is safe.
+- The `--threshold` option controls sensitivity. The default of 75 flags clear mismatches while ignoring minor formatting differences (e.g. `The Beatles` vs `Beatles, The`). Lower it to catch more subtle corruption; raise it if you're seeing false positives.
 
 ---
 

--- a/tagger/integrity/itunes_comparator.py
+++ b/tagger/integrity/itunes_comparator.py
@@ -1,0 +1,197 @@
+"""Compare MP3 ID3 tags against an iTunes Music Library XML ground-truth record."""
+
+from __future__ import annotations
+
+import plistlib
+import urllib.parse
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import structlog
+from pydantic import BaseModel, ConfigDict
+from rapidfuzz import fuzz
+
+from tagger.scanner.id3_reader import read_id3_tags
+from tagger.scanner.walker import find_mp3_files
+
+log = structlog.get_logger(__name__)
+
+# Issue string constants surfaced in AuditDiscrepancy.issues
+ARTIST_MISMATCH = "artist_mismatch"
+ALBUM_ARTIST_MISMATCH = "album_artist_mismatch"
+ALBUM_MISMATCH = "album_mismatch"
+MISSING_TRACK_NUMBER = "missing_track_number"
+ITUNES_NOT_FOUND = "itunes_not_found"
+
+
+class AuditDiscrepancy(BaseModel):
+    """One row in the iTunes audit report — emitted only when issues exist."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    file_path: str
+    artist_folder: str
+    album_folder: str
+    mp3_artist: str | None
+    mp3_album_artist: str | None
+    mp3_album: str | None
+    mp3_track_number: int | None
+    itunes_artist: str | None
+    itunes_album_artist: str | None
+    itunes_album: str | None
+    itunes_track_number: int | None
+    issues: list[str]
+    artist_score: int | None
+    album_artist_score: int | None
+    album_score: int | None
+
+
+class ItunesLibrary:
+    """Parses an iTunes Music Library XML and supports path-based lookup."""
+
+    def __init__(self, xml_path: Path) -> None:
+        with xml_path.open("rb") as fh:
+            plist: dict[str, Any] = plistlib.load(fh, fmt=plistlib.FMT_XML)
+
+        tracks: dict[str, dict[str, Any]] = plist.get("Tracks", {})
+        self._index: dict[str, dict[str, Any]] = {}
+
+        for entry in tracks.values():
+            loc: str = entry.get("Location", "")
+            if not loc:
+                continue
+            # Decode file:/// URL to a filesystem path
+            raw = urllib.parse.unquote(loc.removeprefix("file:///"))
+            # Path() normalises separators; lower() gives case-insensitive lookup
+            win_path = str(Path(raw)).lower()
+            self._index[win_path] = entry
+
+        log.debug("itunes_library.loaded", track_count=len(self._index))
+
+    def lookup(self, mp3_path: Path) -> dict[str, Any] | None:
+        """Return the iTunes track dict for *mp3_path*, or None if not indexed."""
+        key = str(Path(str(mp3_path))).lower()
+        return self._index.get(key)
+
+
+def compare_library(
+    library_path: Path,
+    itunes_xml: Path,
+    threshold: int = 75,
+    workers: int = 4,
+) -> list[AuditDiscrepancy]:
+    """Walk *library_path*, read ID3 tags, and compare against the iTunes record.
+
+    Returns one AuditDiscrepancy per MP3 that has at least one issue.
+    """
+    log.info(
+        "itunes_comparator.start",
+        library=str(library_path),
+        xml=str(itunes_xml),
+        threshold=threshold,
+        workers=workers,
+    )
+
+    library = ItunesLibrary(itunes_xml)
+    log.info("itunes_comparator.library_loaded", track_count=len(library._index))
+
+    mp3_files = find_mp3_files(library_path)
+    log.info("itunes_comparator.files_found", count=len(mp3_files))
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        tag_results: list[dict[str, Any]] = list(pool.map(read_id3_tags, mp3_files))
+
+    results: list[AuditDiscrepancy] = []
+
+    for mp3_path, tags in zip(mp3_files, tag_results, strict=True):
+        # Derive folder names — library structure: <root>/<artist>/<album>/<track>
+        artist_folder = mp3_path.parent.parent.name
+        album_folder = mp3_path.parent.name
+
+        mp3_artist: str | None = tags.get("artist")
+        mp3_album_artist: str | None = tags.get("album_artist")
+        mp3_album: str | None = tags.get("album")
+        mp3_track_number: int | None = tags.get("track_number")
+
+        itunes_entry = library.lookup(mp3_path)
+        issues: list[str] = []
+
+        if itunes_entry is None:
+            issues.append(ITUNES_NOT_FOUND)
+            if mp3_track_number is None:
+                issues.append(MISSING_TRACK_NUMBER)
+            results.append(
+                AuditDiscrepancy(
+                    file_path=str(mp3_path),
+                    artist_folder=artist_folder,
+                    album_folder=album_folder,
+                    mp3_artist=mp3_artist,
+                    mp3_album_artist=mp3_album_artist,
+                    mp3_album=mp3_album,
+                    mp3_track_number=mp3_track_number,
+                    itunes_artist=None,
+                    itunes_album_artist=None,
+                    itunes_album=None,
+                    itunes_track_number=None,
+                    issues=issues,
+                    artist_score=None,
+                    album_artist_score=None,
+                    album_score=None,
+                )
+            )
+            continue
+
+        itunes_artist: str | None = itunes_entry.get("Artist")
+        itunes_album_artist: str | None = itunes_entry.get("Album Artist")
+        itunes_album: str | None = itunes_entry.get("Album")
+        itunes_track_number: int | None = itunes_entry.get("Track Number")
+
+        artist_score = int(
+            fuzz.token_set_ratio((mp3_artist or "").lower(), (itunes_artist or "").lower())
+        )
+        album_artist_score = int(
+            fuzz.token_set_ratio(
+                (mp3_album_artist or "").lower(), (itunes_album_artist or "").lower()
+            )
+        )
+        album_score = int(
+            fuzz.token_set_ratio((mp3_album or "").lower(), (itunes_album or "").lower())
+        )
+
+        if artist_score < threshold:
+            issues.append(ARTIST_MISMATCH)
+        if album_artist_score < threshold:
+            issues.append(ALBUM_ARTIST_MISMATCH)
+        if album_score < threshold:
+            issues.append(ALBUM_MISMATCH)
+        if mp3_track_number is None:
+            issues.append(MISSING_TRACK_NUMBER)
+
+        if issues:
+            results.append(
+                AuditDiscrepancy(
+                    file_path=str(mp3_path),
+                    artist_folder=artist_folder,
+                    album_folder=album_folder,
+                    mp3_artist=mp3_artist,
+                    mp3_album_artist=mp3_album_artist,
+                    mp3_album=mp3_album,
+                    mp3_track_number=mp3_track_number,
+                    itunes_artist=itunes_artist,
+                    itunes_album_artist=itunes_album_artist,
+                    itunes_album=itunes_album,
+                    itunes_track_number=itunes_track_number,
+                    issues=issues,
+                    artist_score=artist_score,
+                    album_artist_score=album_artist_score,
+                    album_score=album_score,
+                )
+            )
+
+    log.info(
+        "itunes_comparator.complete",
+        mp3_count=len(mp3_files),
+        discrepancy_count=len(results),
+    )
+    return results

--- a/tagger/integrity/itunes_comparator.py
+++ b/tagger/integrity/itunes_comparator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import plistlib
+import re
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -61,8 +62,9 @@ class ItunesLibrary:
             loc: str = entry.get("Location", "")
             if not loc:
                 continue
-            # Decode file:/// URL to a filesystem path
-            raw = urllib.parse.unquote(loc.removeprefix("file:///"))
+            # Decode file:// URL — iTunes uses file://localhost/M:/... on Windows
+            no_scheme = re.sub(r"^file://(?:localhost/)?", "", loc)
+            raw = urllib.parse.unquote(no_scheme)
             # Path() normalises separators; lower() gives case-insensitive lookup
             win_path = str(Path(raw)).lower()
             self._index[win_path] = entry

--- a/tagger/integrity/itunes_restorer.py
+++ b/tagger/integrity/itunes_restorer.py
@@ -1,0 +1,191 @@
+"""Restore MP3 ID3 tags from iTunes ground-truth data.
+
+Reads discrepancies produced by compare_library() and writes the correct
+iTunes values back to the MP3 files using mutagen. Only the affected frames
+are overwritten — all other existing tags are preserved.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import structlog
+from mutagen.id3 import ID3, TALB, TPE1, TPE2, TPOS, TRCK, ID3NoHeaderError
+from pydantic import BaseModel, ConfigDict
+
+from tagger.enricher.formatter import parse_track_from_filename
+from tagger.integrity.itunes_comparator import (
+    ALBUM_ARTIST_MISMATCH,
+    ALBUM_MISMATCH,
+    ARTIST_MISMATCH,
+    ITUNES_NOT_FOUND,
+    MISSING_TRACK_NUMBER,
+    AuditDiscrepancy,
+    compare_library,
+)
+
+log = structlog.get_logger(__name__)
+
+
+class RestoreError(Exception):
+    """Raised when a tag write fails for a specific file."""
+
+
+class RestoreResult(BaseModel):
+    """One row in the restore report — emitted for every file acted on."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    file_path: str
+    artist_folder: str
+    album_folder: str
+    fields_restored: list[str]
+    old_artist: str | None
+    new_artist: str | None
+    old_album_artist: str | None
+    new_album_artist: str | None
+    old_album: str | None
+    new_album: str | None
+    old_track_number: int | None
+    new_track_number: int | None
+    dry_run: bool
+
+
+def _write_frames(path: Path, frames: dict[str, Any], dry_run: bool) -> None:
+    """Write *frames* to *path* in place, leaving all other tags untouched."""
+    if dry_run:
+        return
+
+    try:
+        try:
+            tags: ID3 = ID3(str(path))
+        except ID3NoHeaderError:
+            tags = ID3()
+
+        for frame_id, value in frames.items():
+            if frame_id == "TPE1":
+                tags["TPE1"] = TPE1(encoding=3, text=value)
+            elif frame_id == "TPE2":
+                tags["TPE2"] = TPE2(encoding=3, text=value)
+            elif frame_id == "TALB":
+                tags["TALB"] = TALB(encoding=3, text=value)
+            elif frame_id == "TRCK":
+                tags["TRCK"] = TRCK(encoding=3, text=value)
+            elif frame_id == "TPOS":
+                tags["TPOS"] = TPOS(encoding=3, text=value)
+
+        tags.save(str(path), v2_version=3)
+
+    except (PermissionError, OSError) as exc:
+        log.warning("itunes_restorer.write_failed", file=str(path), error=str(exc))
+        raise RestoreError(str(path)) from exc
+
+
+def _resolve_track_number(
+    d: AuditDiscrepancy,
+) -> tuple[int | None, int | None]:
+    """Return (track_number, disc_number) to restore, or (None, None) if unresolvable."""
+    if d.itunes_track_number is not None:
+        return d.itunes_track_number, None
+
+    fn_track, fn_disc = parse_track_from_filename(Path(d.file_path).name)
+    return fn_track, fn_disc
+
+
+def restore_from_itunes(
+    itunes_xml: Path,
+    library_path: Path,
+    threshold: int = 75,
+    workers: int = 4,
+    dry_run: bool = False,
+) -> list[RestoreResult]:
+    """Compare library against iTunes and write correct tag values to MP3 files.
+
+    Returns one RestoreResult per file where at least one field was (or would
+    be) restored. Files matching iTunes or flagged only as itunes_not_found
+    are skipped entirely.
+    """
+    log.info(
+        "itunes_restorer.start",
+        library=str(library_path),
+        xml=str(itunes_xml),
+        dry_run=dry_run,
+    )
+
+    discrepancies = compare_library(
+        library_path=library_path,
+        itunes_xml=itunes_xml,
+        threshold=threshold,
+        workers=workers,
+    )
+
+    results: list[RestoreResult] = []
+
+    for d in discrepancies:
+        if ITUNES_NOT_FOUND in d.issues:
+            continue
+
+        frames: dict[str, Any] = {}
+        fields_restored: list[str] = []
+        new_track_number: int | None = None
+
+        if ARTIST_MISMATCH in d.issues and d.itunes_artist is not None:
+            frames["TPE1"] = d.itunes_artist
+            fields_restored.append("artist")
+
+        if ALBUM_ARTIST_MISMATCH in d.issues and d.itunes_album_artist is not None:
+            frames["TPE2"] = d.itunes_album_artist
+            fields_restored.append("album_artist")
+
+        if ALBUM_MISMATCH in d.issues and d.itunes_album is not None:
+            frames["TALB"] = d.itunes_album
+            fields_restored.append("album")
+
+        if MISSING_TRACK_NUMBER in d.issues:
+            track_num, disc_num = _resolve_track_number(d)
+            if track_num is not None:
+                frames["TRCK"] = str(track_num)
+                if disc_num is not None and disc_num > 1:
+                    frames["TPOS"] = str(disc_num)
+                fields_restored.append("track_number")
+                new_track_number = track_num
+
+        if not fields_restored:
+            continue
+
+        try:
+            if not dry_run:
+                _write_frames(Path(d.file_path), frames, dry_run=False)
+        except RestoreError:
+            log.error("itunes_restorer.skipped_on_error", file=d.file_path)
+            continue
+
+        results.append(
+            RestoreResult(
+                file_path=d.file_path,
+                artist_folder=d.artist_folder,
+                album_folder=d.album_folder,
+                fields_restored=fields_restored,
+                old_artist=d.mp3_artist if "artist" in fields_restored else None,
+                new_artist=d.itunes_artist if "artist" in fields_restored else None,
+                old_album_artist=d.mp3_album_artist if "album_artist" in fields_restored else None,
+                new_album_artist=(
+                    d.itunes_album_artist if "album_artist" in fields_restored else None
+                ),
+                old_album=d.mp3_album if "album" in fields_restored else None,
+                new_album=d.itunes_album if "album" in fields_restored else None,
+                old_track_number=(
+                    d.mp3_track_number if "track_number" in fields_restored else None
+                ),
+                new_track_number=new_track_number,
+                dry_run=dry_run,
+            )
+        )
+
+    log.info(
+        "itunes_restorer.complete",
+        restored=len(results),
+        dry_run=dry_run,
+    )
+    return results

--- a/tagger/mp3_tagger.py
+++ b/tagger/mp3_tagger.py
@@ -1289,5 +1289,112 @@ def audit_itunes(
     click.echo("\n[SUCCESS] audit-itunes complete.")
 
 
+@cli.command("restore-from-itunes")
+@click.option(
+    "--library",
+    "library_path",
+    required=True,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help=r"Path to the music library root (e.g. M:\Shared Music).",
+)
+@click.option(
+    "--itunes-xml",
+    "itunes_xml",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Path to iTunes Music Library.xml.",
+)
+@click.option(
+    "--out",
+    type=Path,
+    default=Path("itunes_restore_report.csv"),
+    show_default=True,
+    help="Output CSV path for the restore report.",
+)
+@click.option(
+    "--threshold",
+    type=int,
+    default=75,
+    show_default=True,
+    help="Fuzzy-match score below which a field is considered mismatched.",
+)
+@click.option(
+    "--workers",
+    type=int,
+    default=4,
+    show_default=True,
+    help="Number of threads for parallel ID3 tag reading.",
+)
+@click.option("--dry-run", is_flag=True, help="Preview changes without writing any files.")
+def restore_from_itunes_cmd(
+    library_path: Path,
+    itunes_xml: Path,
+    out: Path,
+    threshold: int,
+    workers: int,
+    dry_run: bool,
+) -> None:
+    """Restore corrupted MP3 tags from an iTunes Music Library XML record.
+
+    Compares current ID3 tags against the iTunes ground-truth and writes the
+    correct Artist, Album Artist, Album, and Track Number values back to each
+    affected MP3.  Only the mismatched frames are overwritten; all other tags
+    are preserved.  Use --dry-run to preview without modifying any files.
+    """
+    import csv as _csv
+
+    from tagger.integrity.itunes_restorer import restore_from_itunes
+
+    if dry_run:
+        click.echo("[*] Dry-run mode — no files will be modified.")
+    click.echo(f"[*] Loading iTunes library from {itunes_xml} ...")
+    click.echo(f"[*] Scanning {library_path} with {workers} worker(s) ...")
+
+    results = restore_from_itunes(
+        itunes_xml=itunes_xml,
+        library_path=library_path,
+        threshold=threshold,
+        workers=workers,
+        dry_run=dry_run,
+    )
+
+    fieldnames = [
+        "file_path",
+        "artist_folder",
+        "album_folder",
+        "fields_restored",
+        "old_artist",
+        "new_artist",
+        "old_album_artist",
+        "new_album_artist",
+        "old_album",
+        "new_album",
+        "old_track_number",
+        "new_track_number",
+        "dry_run",
+    ]
+
+    with out.open("w", newline="", encoding="utf-8") as f:
+        writer = _csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for r in results:
+            row = r.model_dump()
+            row["fields_restored"] = "|".join(r.fields_restored)
+            writer.writerow(row)
+
+    total = len(results)
+    by_field: dict[str, int] = {}
+    for r in results:
+        for field in r.fields_restored:
+            by_field[field] = by_field.get(field, 0) + 1
+
+    action = "Would restore" if dry_run else "Restored"
+    click.echo(f"[+] {action} {total} file(s).")
+    for field, count in sorted(by_field.items()):
+        click.echo(f"    {field}: {count}")
+    click.echo(f"[+] Report written to {out}")
+    click.echo(f"\n[SUCCESS] restore-from-itunes {'(dry run) ' if dry_run else ''}complete.")
+
+
 if __name__ == "__main__":
     cli()

--- a/tagger/mp3_tagger.py
+++ b/tagger/mp3_tagger.py
@@ -1187,5 +1187,107 @@ def link_scan(db_path: Path, artist: str | None, dry_run: bool, no_llm: bool) ->
     click.echo("[*] Run 'write' to flush changes to ID3 tags.")
 
 
+@cli.command("audit-itunes")
+@click.option(
+    "--library",
+    "library_path",
+    required=True,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help=r"Path to the music library root (e.g. M:\Shared Music).",
+)
+@click.option(
+    "--itunes-xml",
+    "itunes_xml",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Path to iTunes Music Library.xml.",
+)
+@click.option(
+    "--out",
+    type=Path,
+    default=Path("itunes_audit.csv"),
+    show_default=True,
+    help="Output CSV path.",
+)
+@click.option(
+    "--threshold",
+    type=int,
+    default=75,
+    show_default=True,
+    help="Fuzzy-match score below which a field is flagged as mismatched.",
+)
+@click.option(
+    "--workers",
+    type=int,
+    default=4,
+    show_default=True,
+    help="Number of threads for parallel ID3 tag reading.",
+)
+def audit_itunes(
+    library_path: Path,
+    itunes_xml: Path,
+    out: Path,
+    threshold: int,
+    workers: int,
+) -> None:
+    """Compare MP3 ID3 tags against an iTunes XML library record.
+
+    Surfaces Artist / Album Artist / Album discrepancies and missing track
+    numbers by fuzzy-matching current ID3 tags against the iTunes ground-truth
+    record.  Writes a CSV report to --out.
+    """
+    import csv as _csv
+
+    from tagger.integrity.itunes_comparator import compare_library
+
+    click.echo(f"[*] Loading iTunes library from {itunes_xml} ...")
+    click.echo(f"[*] Scanning {library_path} with {workers} worker(s) ...")
+
+    discrepancies = compare_library(
+        library_path=library_path,
+        itunes_xml=itunes_xml,
+        threshold=threshold,
+        workers=workers,
+    )
+
+    fieldnames = [
+        "file_path",
+        "artist_folder",
+        "album_folder",
+        "mp3_artist",
+        "mp3_album_artist",
+        "mp3_album",
+        "mp3_track_number",
+        "itunes_artist",
+        "itunes_album_artist",
+        "itunes_album",
+        "itunes_track_number",
+        "issues",
+        "artist_score",
+        "album_artist_score",
+        "album_score",
+    ]
+
+    with out.open("w", newline="", encoding="utf-8") as f:
+        writer = _csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for d in discrepancies:
+            row = d.model_dump()
+            row["issues"] = "|".join(d.issues)
+            writer.writerow(row)
+
+    total = len(discrepancies)
+    by_issue: dict[str, int] = {}
+    for d in discrepancies:
+        for issue in d.issues:
+            by_issue[issue] = by_issue.get(issue, 0) + 1
+
+    click.echo(f"[+] {total} discrepancy row(s) found.")
+    for issue_name, count in sorted(by_issue.items()):
+        click.echo(f"    {issue_name}: {count}")
+    click.echo(f"[+] Report written to {out}")
+    click.echo("\n[SUCCESS] audit-itunes complete.")
+
+
 if __name__ == "__main__":
     cli()

--- a/tests/unit/integrity/test_itunes_comparator.py
+++ b/tests/unit/integrity/test_itunes_comparator.py
@@ -53,7 +53,12 @@ class TestItunesLibraryLookup:
     def test_lookup_found(self, tmp_path: Path) -> None:
         xml = tmp_path / "library.xml"
         _write_plist(
-            xml, {"1": _make_track(location="file:///M:/Shared%20Music/Artist/Album/01%20Song.mp3")}
+            xml,
+            {
+                "1": _make_track(
+                    location="file://localhost/M:/Shared%20Music/Artist/Album/01%20Song.mp3"
+                )
+            },
         )
         lib = ItunesLibrary(xml)
         result = lib.lookup(Path("M:/Shared Music/Artist/Album/01 Song.mp3"))
@@ -63,7 +68,12 @@ class TestItunesLibraryLookup:
     def test_lookup_not_found(self, tmp_path: Path) -> None:
         xml = tmp_path / "library.xml"
         _write_plist(
-            xml, {"1": _make_track(location="file:///M:/Shared%20Music/Artist/Album/01%20Song.mp3")}
+            xml,
+            {
+                "1": _make_track(
+                    location="file://localhost/M:/Shared%20Music/Artist/Album/01%20Song.mp3"
+                )
+            },
         )
         lib = ItunesLibrary(xml)
         result = lib.lookup(Path("M:/Shared Music/OtherArtist/Album/02 Other.mp3"))
@@ -72,7 +82,12 @@ class TestItunesLibraryLookup:
     def test_lookup_case_insensitive(self, tmp_path: Path) -> None:
         xml = tmp_path / "library.xml"
         _write_plist(
-            xml, {"1": _make_track(location="file:///M:/Shared%20Music/ARTIST/Album/01%20Song.mp3")}
+            xml,
+            {
+                "1": _make_track(
+                    location="file://localhost/M:/Shared%20Music/ARTIST/Album/01%20Song.mp3"
+                )
+            },
         )
         lib = ItunesLibrary(xml)
         # Lookup with different casing
@@ -81,7 +96,9 @@ class TestItunesLibraryLookup:
 
     def test_tracks_with_no_location_are_skipped(self, tmp_path: Path) -> None:
         xml = tmp_path / "library.xml"
-        track = _make_track(location="file:///M:/Shared%20Music/Artist/Album/01%20Song.mp3")
+        track = _make_track(
+            location="file://localhost/M:/Shared%20Music/Artist/Album/01%20Song.mp3"
+        )
         no_loc = {k: v for k, v in track.items() if k != "Location"}
         _write_plist(xml, {"1": no_loc, "2": track})
         lib = ItunesLibrary(xml)
@@ -94,7 +111,7 @@ class TestItunesLibraryLookup:
             xml,
             {
                 "1": _make_track(
-                    location="file:///M:/Shared%20Music/Jay-Z/The%20Blueprint/01%20The%20Ruler%27s%20Back.mp3"
+                    location="file://localhost/M:/Shared%20Music/Jay-Z/The%20Blueprint/01%20The%20Ruler%27s%20Back.mp3"
                 )
             },
         )
@@ -108,7 +125,7 @@ class TestItunesLibraryLookup:
 # ---------------------------------------------------------------------------
 
 MP3_PATH = Path("M:/Shared Music/Some Artist/Some Album/01 Track.mp3")
-LOCATION = "file:///M:/Shared%20Music/Some%20Artist/Some%20Album/01%20Track.mp3"
+LOCATION = "file://localhost/M:/Shared%20Music/Some%20Artist/Some%20Album/01%20Track.mp3"
 
 
 def _run_compare(
@@ -220,7 +237,12 @@ class TestCompareLibrary:
         xml = tmp_path / "library.xml"
         # Plist has a track at a different path
         _write_plist(
-            xml, {"1": _make_track(location="file:///M:/Shared%20Music/Other/Album/01%20Other.mp3")}
+            xml,
+            {
+                "1": _make_track(
+                    location="file://localhost/M:/Shared%20Music/Other/Album/01%20Other.mp3"
+                )
+            },
         )
 
         with (

--- a/tests/unit/integrity/test_itunes_comparator.py
+++ b/tests/unit/integrity/test_itunes_comparator.py
@@ -1,0 +1,329 @@
+"""Unit tests for tagger/integrity/itunes_comparator.py.
+
+Covers ItunesLibrary (plist parsing + lookup) and compare_library
+(discrepancy detection logic). No real filesystem I/O — all fixtures
+use tmp_path or in-memory mocks.
+"""
+
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+from unittest.mock import patch
+
+from tagger.integrity.itunes_comparator import AuditDiscrepancy, ItunesLibrary, compare_library
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_plist(path: Path, tracks: dict[str, dict]) -> None:
+    """Write a minimal iTunes-style plist XML to *path*."""
+    data: dict = {"Tracks": tracks}
+    with path.open("wb") as fh:
+        plistlib.dump(data, fh, fmt=plistlib.FMT_XML)
+
+
+def _make_track(
+    *,
+    location: str,
+    artist: str = "Test Artist",
+    album_artist: str = "Test Album Artist",
+    album: str = "Test Album",
+    track_number: int = 1,
+) -> dict:
+    return {
+        "Track ID": 1,
+        "Name": "Test Track",
+        "Artist": artist,
+        "Album Artist": album_artist,
+        "Album": album,
+        "Track Number": track_number,
+        "Location": location,
+    }
+
+
+# ---------------------------------------------------------------------------
+# ItunesLibrary tests
+# ---------------------------------------------------------------------------
+
+
+class TestItunesLibraryLookup:
+    def test_lookup_found(self, tmp_path: Path) -> None:
+        xml = tmp_path / "library.xml"
+        _write_plist(
+            xml, {"1": _make_track(location="file:///M:/Shared%20Music/Artist/Album/01%20Song.mp3")}
+        )
+        lib = ItunesLibrary(xml)
+        result = lib.lookup(Path("M:/Shared Music/Artist/Album/01 Song.mp3"))
+        assert result is not None
+        assert result["Artist"] == "Test Artist"
+
+    def test_lookup_not_found(self, tmp_path: Path) -> None:
+        xml = tmp_path / "library.xml"
+        _write_plist(
+            xml, {"1": _make_track(location="file:///M:/Shared%20Music/Artist/Album/01%20Song.mp3")}
+        )
+        lib = ItunesLibrary(xml)
+        result = lib.lookup(Path("M:/Shared Music/OtherArtist/Album/02 Other.mp3"))
+        assert result is None
+
+    def test_lookup_case_insensitive(self, tmp_path: Path) -> None:
+        xml = tmp_path / "library.xml"
+        _write_plist(
+            xml, {"1": _make_track(location="file:///M:/Shared%20Music/ARTIST/Album/01%20Song.mp3")}
+        )
+        lib = ItunesLibrary(xml)
+        # Lookup with different casing
+        result = lib.lookup(Path("M:/Shared Music/artist/album/01 song.mp3"))
+        assert result is not None
+
+    def test_tracks_with_no_location_are_skipped(self, tmp_path: Path) -> None:
+        xml = tmp_path / "library.xml"
+        track = _make_track(location="file:///M:/Shared%20Music/Artist/Album/01%20Song.mp3")
+        no_loc = {k: v for k, v in track.items() if k != "Location"}
+        _write_plist(xml, {"1": no_loc, "2": track})
+        lib = ItunesLibrary(xml)
+        # Index should only have the track with a Location
+        assert lib.lookup(Path("M:/Shared Music/Artist/Album/01 Song.mp3")) is not None
+
+    def test_url_encoded_spaces_and_special_chars(self, tmp_path: Path) -> None:
+        xml = tmp_path / "library.xml"
+        _write_plist(
+            xml,
+            {
+                "1": _make_track(
+                    location="file:///M:/Shared%20Music/Jay-Z/The%20Blueprint/01%20The%20Ruler%27s%20Back.mp3"
+                )
+            },
+        )
+        lib = ItunesLibrary(xml)
+        result = lib.lookup(Path("M:/Shared Music/Jay-Z/The Blueprint/01 The Ruler's Back.mp3"))
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# compare_library tests
+# ---------------------------------------------------------------------------
+
+MP3_PATH = Path("M:/Shared Music/Some Artist/Some Album/01 Track.mp3")
+LOCATION = "file:///M:/Shared%20Music/Some%20Artist/Some%20Album/01%20Track.mp3"
+
+
+def _run_compare(
+    tmp_path: Path,
+    *,
+    itunes_artist: str = "Some Artist",
+    itunes_album_artist: str = "Some Artist",
+    itunes_album: str = "Some Album",
+    itunes_track_number: int = 1,
+    mp3_tags: dict,
+    threshold: int = 75,
+) -> list[AuditDiscrepancy]:
+    """Build a single-track plist and run compare_library with mocked I/O."""
+    xml = tmp_path / "library.xml"
+    _write_plist(
+        xml,
+        {
+            "1": _make_track(
+                location=LOCATION,
+                artist=itunes_artist,
+                album_artist=itunes_album_artist,
+                album=itunes_album,
+                track_number=itunes_track_number,
+            )
+        },
+    )
+
+    with (
+        patch("tagger.integrity.itunes_comparator.find_mp3_files", return_value=[MP3_PATH]),
+        patch("tagger.integrity.itunes_comparator.read_id3_tags", return_value=mp3_tags),
+    ):
+        return compare_library(
+            library_path=Path("M:/Shared Music"),
+            itunes_xml=xml,
+            threshold=threshold,
+            workers=1,
+        )
+
+
+class TestCompareLibrary:
+    def test_no_discrepancy_on_perfect_match(self, tmp_path: Path) -> None:
+        results = _run_compare(
+            tmp_path,
+            mp3_tags={
+                "artist": "Some Artist",
+                "album_artist": "Some Artist",
+                "album": "Some Album",
+                "track_number": 1,
+            },
+        )
+        assert results == []
+
+    def test_artist_mismatch_flagged(self, tmp_path: Path) -> None:
+        results = _run_compare(
+            tmp_path,
+            itunes_artist="Correct Artist",
+            mp3_tags={
+                "artist": "Completely Wrong",
+                "album_artist": "Some Artist",
+                "album": "Some Album",
+                "track_number": 1,
+            },
+        )
+        assert len(results) == 1
+        assert "artist_mismatch" in results[0].issues
+        assert "album_artist_mismatch" not in results[0].issues
+        assert "album_mismatch" not in results[0].issues
+
+    def test_album_artist_mismatch_flagged(self, tmp_path: Path) -> None:
+        results = _run_compare(
+            tmp_path,
+            itunes_album_artist="Beethoven Ludwig Van",
+            mp3_tags={
+                "artist": "Some Artist",
+                "album_artist": "Radiohead",
+                "album": "Some Album",
+                "track_number": 1,
+            },
+        )
+        assert any("album_artist_mismatch" in r.issues for r in results)
+
+    def test_album_mismatch_flagged(self, tmp_path: Path) -> None:
+        results = _run_compare(
+            tmp_path,
+            itunes_album="Correct Album Title",
+            mp3_tags={
+                "artist": "Some Artist",
+                "album_artist": "Some Artist",
+                "album": "Completely Different Album",
+                "track_number": 1,
+            },
+        )
+        assert any("album_mismatch" in r.issues for r in results)
+
+    def test_missing_track_number_flagged(self, tmp_path: Path) -> None:
+        results = _run_compare(
+            tmp_path,
+            mp3_tags={
+                "artist": "Some Artist",
+                "album_artist": "Some Artist",
+                "album": "Some Album",
+                # track_number intentionally absent
+            },
+        )
+        assert len(results) == 1
+        assert results[0].issues == ["missing_track_number"]
+
+    def test_itunes_not_found(self, tmp_path: Path) -> None:
+        xml = tmp_path / "library.xml"
+        # Plist has a track at a different path
+        _write_plist(
+            xml, {"1": _make_track(location="file:///M:/Shared%20Music/Other/Album/01%20Other.mp3")}
+        )
+
+        with (
+            patch("tagger.integrity.itunes_comparator.find_mp3_files", return_value=[MP3_PATH]),
+            patch(
+                "tagger.integrity.itunes_comparator.read_id3_tags",
+                return_value={
+                    "artist": "Some Artist",
+                    "album_artist": "Some Artist",
+                    "album": "Some Album",
+                    "track_number": 1,
+                },
+            ),
+        ):
+            results = compare_library(
+                library_path=Path("M:/Shared Music"),
+                itunes_xml=xml,
+                threshold=75,
+                workers=1,
+            )
+
+        assert len(results) == 1
+        assert "itunes_not_found" in results[0].issues
+
+    def test_threshold_boundary_below_flags(self, tmp_path: Path) -> None:
+        """Score strictly below threshold triggers a mismatch flag."""
+        results = _run_compare(
+            tmp_path,
+            itunes_artist="Alpha",
+            mp3_tags={
+                "artist": "Completely Unrelated Name",
+                "album_artist": "Some Artist",
+                "album": "Some Album",
+                "track_number": 1,
+            },
+            threshold=75,
+        )
+        assert any("artist_mismatch" in r.issues for r in results)
+
+    def test_threshold_boundary_at_or_above_does_not_flag(self, tmp_path: Path) -> None:
+        """Score at or above threshold does not trigger mismatch."""
+        results = _run_compare(
+            tmp_path,
+            itunes_artist="Some Artist",
+            mp3_tags={
+                "artist": "Some Artist",
+                "album_artist": "Some Artist",
+                "album": "Some Album",
+                "track_number": 1,
+            },
+            threshold=75,
+        )
+        assert results == []
+
+    def test_multiple_issues_in_single_row(self, tmp_path: Path) -> None:
+        """A track can have several issues at once."""
+        results = _run_compare(
+            tmp_path,
+            itunes_artist="Original Artist",
+            itunes_album="Original Album",
+            mp3_tags={
+                "artist": "Wrong Artist XYZ",
+                "album_artist": "Some Artist",
+                "album": "Wrong Album XYZ",
+                # track_number absent
+            },
+        )
+        assert len(results) == 1
+        issues = results[0].issues
+        assert "artist_mismatch" in issues
+        assert "album_mismatch" in issues
+        assert "missing_track_number" in issues
+
+    def test_discrepancy_fields_populated(self, tmp_path: Path) -> None:
+        """AuditDiscrepancy carries both sides of the comparison."""
+        results = _run_compare(
+            tmp_path,
+            itunes_artist="Beethoven",
+            mp3_tags={
+                "artist": "Radiohead",
+                "album_artist": "Some Artist",
+                "album": "Some Album",
+                "track_number": 1,
+            },
+        )
+        assert len(results) == 1
+        d = results[0]
+        assert d.mp3_artist == "Radiohead"
+        assert d.itunes_artist == "Beethoven"
+        assert d.artist_folder == "Some Artist"
+        assert d.album_folder == "Some Album"
+        assert d.artist_score is not None
+        assert 0 <= d.artist_score <= 100
+
+    def test_empty_library_returns_empty(self, tmp_path: Path) -> None:
+        xml = tmp_path / "library.xml"
+        _write_plist(xml, {})
+
+        with patch("tagger.integrity.itunes_comparator.find_mp3_files", return_value=[]):
+            results = compare_library(
+                library_path=Path("M:/Shared Music"),
+                itunes_xml=xml,
+                threshold=75,
+                workers=1,
+            )
+        assert results == []

--- a/tests/unit/integrity/test_itunes_restorer.py
+++ b/tests/unit/integrity/test_itunes_restorer.py
@@ -1,0 +1,247 @@
+"""Unit tests for tagger/integrity/itunes_restorer.py.
+
+Covers restore_from_itunes logic (which fields get written, dry-run,
+fallback to filename, itunes_not_found skipping). All mutagen I/O and
+compare_library calls are mocked — no real filesystem or iTunes XML needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from tagger.integrity.itunes_comparator import (
+    ALBUM_ARTIST_MISMATCH,
+    ALBUM_MISMATCH,
+    ARTIST_MISMATCH,
+    ITUNES_NOT_FOUND,
+    MISSING_TRACK_NUMBER,
+    AuditDiscrepancy,
+)
+from tagger.integrity.itunes_restorer import RestoreResult, restore_from_itunes
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_LIBRARY = Path("M:/Shared Music")
+_ITUNES_XML = Path("C:/iTunes/iTunes Music Library.xml")
+_MP3 = Path("M:/Shared Music/Some Artist/Some Album/01 Track.mp3")
+
+
+def _discrepancy(
+    *,
+    file_path: str = str(_MP3),
+    artist_folder: str = "Some Artist",
+    album_folder: str = "Some Album",
+    issues: list[str],
+    mp3_artist: str | None = "Wrong Artist",
+    mp3_album_artist: str | None = "Wrong Album Artist",
+    mp3_album: str | None = "Wrong Album",
+    mp3_track_number: int | None = None,
+    itunes_artist: str | None = "Correct Artist",
+    itunes_album_artist: str | None = "Correct Album Artist",
+    itunes_album: str | None = "Correct Album",
+    itunes_track_number: int | None = 1,
+    artist_score: int | None = 10,
+    album_artist_score: int | None = 10,
+    album_score: int | None = 10,
+) -> AuditDiscrepancy:
+    return AuditDiscrepancy(
+        file_path=file_path,
+        artist_folder=artist_folder,
+        album_folder=album_folder,
+        mp3_artist=mp3_artist,
+        mp3_album_artist=mp3_album_artist,
+        mp3_album=mp3_album,
+        mp3_track_number=mp3_track_number,
+        itunes_artist=itunes_artist,
+        itunes_album_artist=itunes_album_artist,
+        itunes_album=itunes_album,
+        itunes_track_number=itunes_track_number,
+        issues=issues,
+        artist_score=artist_score,
+        album_artist_score=album_artist_score,
+        album_score=album_score,
+    )
+
+
+def _run_restore(
+    discrepancies: list[AuditDiscrepancy],
+    *,
+    dry_run: bool = False,
+) -> list[RestoreResult]:
+    with (
+        patch(
+            "tagger.integrity.itunes_restorer.compare_library",
+            return_value=discrepancies,
+        ),
+        patch("tagger.integrity.itunes_restorer._write_frames") as mock_write,
+    ):
+        results = restore_from_itunes(
+            itunes_xml=_ITUNES_XML,
+            library_path=_LIBRARY,
+            threshold=75,
+            workers=1,
+            dry_run=dry_run,
+        )
+    return results, mock_write  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreFromItunes:
+    def test_artist_mismatch_restores_tpe1(self) -> None:
+        results, mock_write = _run_restore(
+            [_discrepancy(issues=[ARTIST_MISMATCH], itunes_artist="Correct Artist")]
+        )
+        assert len(results) == 1
+        assert "artist" in results[0].fields_restored
+        assert results[0].new_artist == "Correct Artist"
+        assert results[0].old_artist == "Wrong Artist"
+        mock_write.assert_called_once()
+        frames = mock_write.call_args[0][1]
+        assert "TPE1" in frames
+        assert frames["TPE1"] == "Correct Artist"
+
+    def test_album_mismatch_restores_talb(self) -> None:
+        results, mock_write = _run_restore(
+            [_discrepancy(issues=[ALBUM_MISMATCH], itunes_album="Correct Album")]
+        )
+        assert len(results) == 1
+        assert "album" in results[0].fields_restored
+        assert results[0].new_album == "Correct Album"
+        frames = mock_write.call_args[0][1]
+        assert "TALB" in frames
+
+    def test_album_artist_mismatch_restores_tpe2(self) -> None:
+        results, mock_write = _run_restore(
+            [
+                _discrepancy(
+                    issues=[ALBUM_ARTIST_MISMATCH],
+                    itunes_album_artist="Correct Album Artist",
+                )
+            ]
+        )
+        assert len(results) == 1
+        assert "album_artist" in results[0].fields_restored
+        frames = mock_write.call_args[0][1]
+        assert "TPE2" in frames
+        assert frames["TPE2"] == "Correct Album Artist"
+
+    def test_missing_track_number_uses_itunes_value(self) -> None:
+        results, mock_write = _run_restore(
+            [
+                _discrepancy(
+                    issues=[MISSING_TRACK_NUMBER],
+                    mp3_track_number=None,
+                    itunes_track_number=5,
+                )
+            ]
+        )
+        assert len(results) == 1
+        assert "track_number" in results[0].fields_restored
+        assert results[0].new_track_number == 5
+        frames = mock_write.call_args[0][1]
+        assert frames["TRCK"] == "5"
+
+    def test_missing_track_number_falls_back_to_filename(self) -> None:
+        d = _discrepancy(
+            file_path="M:/Shared Music/Some Artist/Some Album/03 Song.mp3",
+            issues=[MISSING_TRACK_NUMBER],
+            mp3_track_number=None,
+            itunes_track_number=None,
+        )
+        results, mock_write = _run_restore([d])
+        assert len(results) == 1
+        assert "track_number" in results[0].fields_restored
+        assert results[0].new_track_number == 3
+        frames = mock_write.call_args[0][1]
+        assert frames["TRCK"] == "3"
+
+    def test_missing_track_number_no_itunes_no_filename_skips_field(self) -> None:
+        d = _discrepancy(
+            file_path="M:/Shared Music/Some Artist/Some Album/Track With No Number.mp3",
+            issues=[MISSING_TRACK_NUMBER],
+            mp3_track_number=None,
+            itunes_track_number=None,
+        )
+        results, _mock_write = _run_restore([d])
+        # No track number resolvable — row should not be emitted at all
+        # (nothing to restore on this file)
+        assert all("track_number" not in r.fields_restored for r in results)
+
+    def test_itunes_not_found_skipped(self) -> None:
+        results, mock_write = _run_restore([_discrepancy(issues=[ITUNES_NOT_FOUND])])
+        assert results == []
+        mock_write.assert_not_called()
+
+    def test_itunes_not_found_with_missing_track_skipped(self) -> None:
+        results, mock_write = _run_restore(
+            [_discrepancy(issues=[ITUNES_NOT_FOUND, MISSING_TRACK_NUMBER])]
+        )
+        assert results == []
+        mock_write.assert_not_called()
+
+    def test_dry_run_emits_result_but_no_write(self) -> None:
+        results, mock_write = _run_restore(
+            [_discrepancy(issues=[ARTIST_MISMATCH])],
+            dry_run=True,
+        )
+        assert len(results) == 1
+        assert results[0].dry_run is True
+        mock_write.assert_not_called()
+
+    def test_multiple_fields_in_one_file(self) -> None:
+        d = _discrepancy(
+            issues=[ARTIST_MISMATCH, ALBUM_MISMATCH, MISSING_TRACK_NUMBER],
+            itunes_track_number=7,
+        )
+        results, mock_write = _run_restore([d])
+        assert len(results) == 1
+        fields = results[0].fields_restored
+        assert "artist" in fields
+        assert "album" in fields
+        assert "track_number" in fields
+        frames = mock_write.call_args[0][1]
+        assert "TPE1" in frames
+        assert "TALB" in frames
+        assert "TRCK" in frames
+
+    def test_empty_discrepancies_returns_empty(self) -> None:
+        results, mock_write = _run_restore([])
+        assert results == []
+        mock_write.assert_not_called()
+
+    def test_disc_number_written_when_greater_than_one(self) -> None:
+        d = _discrepancy(
+            file_path="M:/Shared Music/Some Artist/Some Album/2-03 Song.mp3",
+            issues=[MISSING_TRACK_NUMBER],
+            mp3_track_number=None,
+            itunes_track_number=None,
+        )
+        results, mock_write = _run_restore([d])
+        assert len(results) == 1
+        frames = mock_write.call_args[0][1]
+        assert frames["TRCK"] == "3"
+        assert frames.get("TPOS") == "2"
+
+    def test_result_fields_populated(self) -> None:
+        results, _ = _run_restore(
+            [
+                _discrepancy(
+                    issues=[ARTIST_MISMATCH],
+                    mp3_artist="Old Artist",
+                    itunes_artist="New Artist",
+                )
+            ]
+        )
+        r = results[0]
+        assert r.old_artist == "Old Artist"
+        assert r.new_artist == "New Artist"
+        assert r.artist_folder == "Some Artist"
+        assert r.album_folder == "Some Album"
+        assert r.dry_run is False


### PR DESCRIPTION
## Summary

- Adds `audit-itunes` CLI command that compares current MP3 ID3 tags against an iTunes Music Library XML record to surface corrupted tags from prior enrichment runs
- Fixes `ItunesLibrary` path parsing bug: iTunes uses `file://localhost/M:/...` not `file:///M:/...`, causing 100% of tracks to return as `itunes_not_found`
- Adds `restore-from-itunes` CLI command that writes correct iTunes values (Artist, Album Artist, Album, Track Number) back to affected MP3s — only the mismatched frames are overwritten, all other tags are preserved
- Track numbers fall back to filename-prefix parsing (`03 Song.mp3` → 3) when iTunes has no value

## New files

- `tagger/integrity/itunes_comparator.py` — `ItunesLibrary` (plist parser + path index), `AuditDiscrepancy` model, `compare_library()`
- `tagger/integrity/itunes_restorer.py` — `RestoreResult` model, `restore_from_itunes()`, `_write_frames()`
- `tests/unit/integrity/test_itunes_comparator.py` — 16 unit tests
- `tests/unit/integrity/test_itunes_restorer.py` — 13 unit tests

## Usage

```powershell
# 1. Audit — see what's mismatched
python tagger/mp3_tagger.py audit-itunes \
  --library "M:\Shared Music" \
  --itunes-xml "C:\path\to\iTunes Music Library.xml" \
  --out itunes_audit.csv

# 2. Dry-run restore — preview changes
python tagger/mp3_tagger.py restore-from-itunes \
  --library "M:\Shared Music" \
  --itunes-xml "C:\path\to\iTunes Music Library.xml" \
  --out restore_report.csv --dry-run

# 3. Apply the fix
python tagger/mp3_tagger.py restore-from-itunes \
  --library "M:\Shared Music" \
  --itunes-xml "C:\path\to\iTunes Music Library.xml" \
  --out restore_report.csv
```

## Test plan

- [ ] 29 unit tests pass across both test files
- [ ] Full suite passes with coverage ≥ 90%
- [ ] `mypy tagger/` and `ruff check .` clean
- [ ] Re-run `audit-itunes` — confirm iTunes columns are now populated (path bug fixed)
- [ ] Dry-run `restore-from-itunes` — spot-check `restore_report.csv` for correct old/new values
- [ ] Run for real on a small subset, verify tags in a music player

🤖 Generated with [Claude Code](https://claude.com/claude-code)