### PR TITLE
chore(ci): add Dependabot config for pip and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` covering the `pip` and `github-actions` ecosystems
- Weekly (Monday) schedule, minor/patch updates grouped per ecosystem to keep PR volume manageable, major bumps stay individual for manual review, 5 open-PR cap per ecosystem

## Test Plan
- [x] YAML validated locally, matches Dependabot v2 schema
- [x] No Python files changed — pre-push hook (ruff/mypy/pytest) passed clean
- [ ] After merge, confirm GitHub accepts the config with no parse-error banner on Insights → Dependency graph → Dependabot